### PR TITLE
add custom api auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Alternatively, you can configure Basic Authentication through the UI, as describ
 If your application uses Basic Authentication, you can setup Swagger to send the username and password to the server with each request to your API:
 
 ```ruby
-GrapeSwaggerRails.options.api_auth     = 'basic' # Or 'bearer' for OAuth
+GrapeSwaggerRails.options.api_auth     = 'basic' # Or 'bearer' for OAuth or 'custom' (see below)
 GrapeSwaggerRails.options.api_key_name = 'Authorization'
 GrapeSwaggerRails.options.api_key_type = 'header'
 ```
@@ -66,6 +66,17 @@ Now you can specify the username and password to your API in the Swagger "API ke
 
 The javascript that loads on the Swagger page automatically encodes the username and password and adds the authorization header to your API request.
 See the official Swagger documentation about [Custom Header Parameters](https://github.com/wordnik/swagger-ui#custom-header-parameters---for-basic-auth-etc)
+
+If your application uses an authorization scheme other than basic or bearer, you can specify the prefix using the 'custom' api_auth option:
+
+```ruby
+GrapeSwaggerRails.options.api_auth       = 'custom'
+GrapeSwaggerRails.options.api_key_name   = 'Authorization'
+GrapeSwaggerRails.options.api_key_type   = 'header'
+GrapeSwaggerRails.options.api_key_prefix = 'Token user_token='
+```
+
+This will result in an Authorization header of "Token user_token=api_key"
 
 ### API Token Authentication
 

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -38,7 +38,9 @@
         if (options.api_auth == 'basic') {
           key = "Basic " + Base64.encode(key);
         } else if (options.api_auth == 'bearer') {
-          key = "Bearer " + key
+          key = "Bearer " + key;
+        } else if (options.api_auth == 'custom') {
+          key = options.api_key_prefix + key;
         }
         window.authorizations.add("key", new ApiKeyAuthorization(options.api_key_name, key, options.api_key_type));
       } else {

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -21,9 +21,10 @@ module GrapeSwaggerRails
 
     headers:              {},
 
-    api_auth:             '',        # 'basic' or 'bearer'
+    api_auth:             '',        # 'basic' or 'bearer' or 'custom'
     api_key_name:         'api_key', # 'Authorization'
     api_key_type:         'query',   # 'header'
+    api_key_prefix:       '',        # 'Token user_token='
 
     before_filter_proc:   nil # Proc used as a controller before filter
   )


### PR DESCRIPTION
This provides support for the headers provided by ember-simple-auth-devise

ember-simple-auth-devise provides an Authorization header of "Token user_token=asdf". This commit adds a 'custom' setting to api_auth options and a new api_key_prefix option which is prepended to the key specified in the swagger ui.

Edit: I just saw that swagger added custom header support here: https://github.com/tim-vandecasteele/grape-swagger/pull/9. Not quite as nice as specifying the key once at the top of the page, but a usable workaround.