### PR TITLE
remove grape-swagger version

### DIFF
--- a/grape-swagger-rails.gemspec
+++ b/grape-swagger-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib)
 
   spec.add_dependency 'railties', '>= 3.2.12'
-  spec.add_dependency 'grape-swagger', '>= 0.7.2'
+  spec.add_dependency 'grape-swagger' #, '>= 0.7.2'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Fix NameError (uninitialized class variable @@hide_format in #Class:0x00000006debf88):
see https://github.com/tim-vandecasteele/grape-swagger/issues/60