### PR TITLE
Use marshal_dump on GemSwaggerRails.options for Ruby <2.0

### DIFF
--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-swagger-options="<%= GrapeSwaggerRails.options.to_h.to_json %>">
+<html data-swagger-options="<%= GrapeSwaggerRails.options.marshal_dump.to_json %>">
 <head>
   <title><%= GrapeSwaggerRails.options.app_name || 'Swagger UI' %></title>
   <link href='//fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'/>


### PR DESCRIPTION
GrapeSwaggerRails.options is an instance of OpenStruct, and therefore calling .to_h on it returns nil for pre-Ruby 2.0 implementations. Currently, this breaks the swagger ui and prevents it from loading properly. Calling .marshal_dump instead allows the swagger ui to load without javascript errors. 